### PR TITLE
Issue #8 : Move reviewer field to existing tab group

### DIFF
--- a/workbench_reviewer.module
+++ b/workbench_reviewer.module
@@ -38,7 +38,7 @@ function workbench_reviewer_entity_field_storage_info(\Drupal\Core\Entity\Entity
   if ($entity_type->id() == 'node') {
     $definitions['workbench_reviewer'] = \Drupal\Core\Field\BaseFieldDefinition::create('entity_reference')
       ->setName('workbench_reviewer')
-      ->setLabel(t('Workbench Reviewer'))
+      ->setLabel(t('Request review'))
       ->setTargetEntityTypeId($entity_type->id())
       ->setSetting('target_type', 'user');
     return $definitions;

--- a/workbench_reviewer.module
+++ b/workbench_reviewer.module
@@ -18,7 +18,7 @@ function workbench_reviewer_entity_bundle_field_info(\Drupal\Core\Entity\EntityT
       ->setDisplayConfigurable('form', FALSE)
       ->setDisplayOptions('form', array(
         'type' => 'entity_reference_autocomplete',
-        'weight' => -100,
+        'weight' => 100,
         'settings' => array(
           'size' => 60,
           'match_operator' => 'CONTAINS',
@@ -49,24 +49,8 @@ function workbench_reviewer_entity_field_storage_info(\Drupal\Core\Entity\Entity
  *
  */
 function workbench_reviewer_form_node_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
-  // Create a workflow section in the right "advanced" sidebar.
-  $form['workflow'] = [
-    '#type' => 'details',
-    '#title' => t('Workflow'),
-    '#group' => 'advanced',
-    '#attributes' => [
-      'class' => ['node-form-options']
-    ],
-    '#attached' => [
-      'library' => ['node/drupal.node'],
-    ],
-    '#weight' => 100,
-    '#optional' => FALSE
-  ];
-
-  // Move the Workbench Reviewer field to a new "Workflow" tab.
-  $form['revision_log']['#group'] = 'workflow';
-  $form['workbench_reviewer']['#group'] = 'workflow';
+  // Move the Workbench Reviewer field to the 'meta' tab group.
+  $form['workbench_reviewer']['#group'] = 'meta';
 }
 
 /**

--- a/workbench_reviewer.module
+++ b/workbench_reviewer.module
@@ -9,7 +9,8 @@ function workbench_reviewer_entity_bundle_field_info(\Drupal\Core\Entity\EntityT
   // Only add the reviewer field for bundles that are under moderation.
   if ($entity_type->id() == 'node' && array_key_exists('moderation_state', $base_field_definitions)) {
     $definitions['workbench_reviewer'] = \Drupal\Core\Field\BaseFieldDefinition::create('entity_reference')
-      ->setLabel('Workbench Reviewer')
+      ->setLabel(t('Request review'))
+      ->setDescription(t('Enter the name of the user who should review this change.'))
       ->setDisplayConfigurable('view', TRUE)
       ->setDisplayOptions('view', array(
         'label' => 'hidden',

--- a/workbench_reviewer.module
+++ b/workbench_reviewer.module
@@ -10,7 +10,7 @@ function workbench_reviewer_entity_bundle_field_info(\Drupal\Core\Entity\EntityT
   if ($entity_type->id() == 'node' && array_key_exists('moderation_state', $base_field_definitions)) {
     $definitions['workbench_reviewer'] = \Drupal\Core\Field\BaseFieldDefinition::create('entity_reference')
       ->setLabel(t('Request review'))
-      ->setDescription(t('Enter the name of the user who should review this change.'))
+      ->setDescription(t('Optional: Enter the name of the user who should review this change.'))
       ->setDisplayConfigurable('view', TRUE)
       ->setDisplayOptions('view', array(
         'label' => 'hidden',
@@ -35,6 +35,7 @@ function workbench_reviewer_entity_bundle_field_info(\Drupal\Core\Entity\EntityT
  * Implements hook_entity_field_storage_info().
  */
 function workbench_reviewer_entity_field_storage_info(\Drupal\Core\Entity\EntityTypeInterface $entity_type) {
+  // Adds the field for Workbench Reviewer to entity that are nodes.
   if ($entity_type->id() == 'node') {
     $definitions['workbench_reviewer'] = \Drupal\Core\Field\BaseFieldDefinition::create('entity_reference')
       ->setName('workbench_reviewer')
@@ -58,7 +59,7 @@ function workbench_reviewer_form_node_form_alter(&$form, \Drupal\Core\Form\FormS
  * Implements hook_preprocess_page().
  */
 function workbench_reviewer_preprocess_page(&$variables) {
-  // For admin pages, add in our library.
+  // For admin pages, add in our library CSS and other assets.
   if ($variables['is_admin']) {
     $variables['#attached']['library'][] = 'workbench_reviewer/workbench_reviewer';
   }


### PR DESCRIPTION
Addresses issue #8 .

Moves the reviewer field to the existing tab group that contains the revision log message.

### To test
1. Checkout this branch
1. Clear the cache
1. Create a new node that is under moderation.
1. The _Reviewer_ field should have moved.